### PR TITLE
Remove ID Type character from Power Outlet ID in EvseIdIso

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.11

--- a/src/main/scala/com/thenewmotion/mobilityid/EvseId.scala
+++ b/src/main/scala/com/thenewmotion/mobilityid/EvseId.scala
@@ -4,13 +4,13 @@ import scala.util.matching.Regex
 
 @SerialVersionUID(0)
 trait EvseId {
-  val countryCode: CountryId
-  val operatorId: OperatorId
-  val powerOutletId: String
+  def countryCode: CountryId
+  def operatorId: OperatorId
+  def powerOutletId: String
 
   protected val separator = "*"
 
-  private val normalizedId =
+  protected def normalizedId =
     List(countryCode, operatorId, powerOutletId).mkString(separator)
 
   override def toString = normalizedId
@@ -20,10 +20,10 @@ private case class Error(priority: Int, desc: String)
 
 trait EvseIdFormat[T <: EvseId] {
   def Description: String
-  val CountryCodeRegex: Regex
-  val OperatorCode: Regex
-  val PowerOutletId: Regex
-  val EvseIdRegex: Regex
+  def CountryCodeRegex: Regex
+  def OperatorCode: Regex
+  def PowerOutletId: Regex
+  def EvseIdRegex: Regex
 
   def apply(countryCode: String, operatorId: String, powerOutletId: String): T =
     validateAndCreate(countryCode.toUpperCase, operatorId.toUpperCase, powerOutletId.toUpperCase)
@@ -31,26 +31,28 @@ trait EvseIdFormat[T <: EvseId] {
   private[mobilityid] def create(countryCode: String, operatorId: String, powerOutletId: String): T
 
   def apply(evseId: String): Option[T] = {
+    val IdRegex = EvseIdRegex
     evseId match {
-      case EvseIdRegex(c, o, po) => Some(apply(c, o, po))
+      case IdRegex(c, o, po) => Some(apply(c, o, po))
       case _ => None
     }
   }
 
-  // _Could_ be done much nicer with scalaz disjunction, but I don't want to increase the size of the lib :)
-  private[mobilityid] def validate(countryCode: String, operatorId: String, powerOutletId: String): Either[Error, T] = {
-    CountryCodeRegex.unapplySeq(countryCode) match {
-      case Some(_) =>
-        OperatorCode.unapplySeq(operatorId) match {
-          case Some(_) =>
-            PowerOutletId.unapplySeq(powerOutletId) match {
-              case Some(_) => Right(create(countryCode.toUpperCase, operatorId.toUpperCase, powerOutletId.toUpperCase))
-              case _ => Left(Error(3, s"Invalid powerOutletId for $Description format"))
-            }
-          case _ => Left(Error(2, s"Invalid operatorId for $Description format"))
-        }
-      case _ => Left(Error(1, "Invalid countryCode for ISO or DIN format"))
-    }
+  private[mobilityid] def validate
+    (countryCode: String, operatorId: String, powerOutletId: String): Either[Error, T] = {
+
+    def parse(part: String, regex: Regex, err: => Error) =
+      regex.unapplySeq(part).toRight(err).right
+
+    for {
+      _ <- parse(countryCode, CountryCodeRegex,
+        Error(1, "Invalid countryCode for ISO or DIN format"))
+      _ <- parse(operatorId, OperatorCode,
+        Error(2, s"Invalid operatorId for $Description format"))
+      _ <- parse(powerOutletId, PowerOutletId,
+        Error(3, s"Invalid powerOutletId for $Description format"))
+    } yield
+      create(countryCode.toUpperCase, operatorId.toUpperCase, powerOutletId.toUpperCase)
   }
 
   private[mobilityid] def validateAndCreate(countryCode: String, operatorId: String, powerOutletId: String): T =
@@ -113,8 +115,9 @@ object EvseIdIso extends EvseIdFormat[EvseIdIso] {
   val Description = "ISO"
   val CountryCodeRegex = """([A-Za-z]{2})""".r
   val OperatorCode = """([A-Za-z0-9]{3})""".r
-  val PowerOutletId = """(E[A-Za-z0-9\*]{1,30})""".r
-  val EvseIdRegex = s"""$CountryCodeRegex\\*?$OperatorCode\\*?$PowerOutletId""".r
+  val IdType = "E"
+  val PowerOutletId = """([A-Za-z0-9\*]{1,30})""".r
+  val EvseIdRegex = s"""$CountryCodeRegex\\*?$OperatorCode\\*?$IdType$PowerOutletId""".r
 
   private[mobilityid] override def create(cc: String, operatorId: String, powerOutletId: String): EvseIdIso = {
     EvseIdIsoImpl(CountryCode(cc), OperatorId(operatorId), powerOutletId)
@@ -122,7 +125,7 @@ object EvseIdIso extends EvseIdFormat[EvseIdIso] {
 }
 
 trait EvseIdIso extends EvseId {
-  def toCompactString: String
+  def toCompactString: String = toString.replace(separator, "")
 }
 
 private case class EvseIdIsoImpl (
@@ -130,7 +133,7 @@ private case class EvseIdIsoImpl (
   operatorId: OperatorId,
   powerOutletId: String
 ) extends EvseIdIso {
-  def toCompactString =
-      countryCode.toString + operatorId.toString + powerOutletId.replace(separator, "")
+  override def normalizedId =
+    Seq(countryCode, operatorId, EvseIdIso.IdType + powerOutletId).mkString(separator)
 }
 

--- a/src/main/scala/com/thenewmotion/mobilityid/EvseId.scala
+++ b/src/main/scala/com/thenewmotion/mobilityid/EvseId.scala
@@ -116,7 +116,7 @@ object EvseIdIso extends EvseIdFormat[EvseIdIso] {
   val CountryCodeRegex = """([A-Za-z]{2})""".r
   val OperatorCode = """([A-Za-z0-9]{3})""".r
   val IdType = "E"
-  val PowerOutletId = """([A-Za-z0-9\*]{1,30})""".r
+  val PowerOutletId = """([A-Za-z0-9][A-Za-z0-9\*]{0,30})""".r
   val EvseIdRegex = s"""$CountryCodeRegex\\*?$OperatorCode\\*?$IdType$PowerOutletId""".r
 
   private[mobilityid] override def create(cc: String, operatorId: String, powerOutletId: String): EvseIdIso = {

--- a/src/test/scala/com/thenewmotion/mobilityid/EvseIdSpec.scala
+++ b/src/test/scala/com/thenewmotion/mobilityid/EvseIdSpec.scala
@@ -24,7 +24,8 @@ class EvseIdSpec extends Specification {
       }
 
       "Reject an ISO EvseId String that is too long" in {
-        EvseId("DE*AB7*E1234567890ABCDEFGHIJ1234567890A") must beNone
+        val tooLongOutledId = Seq.fill(32)(7).mkString
+        EvseId(s"DE*AB7*E$tooLongOutledId") must beNone
       }
 
       "Reject an ISO EvseId String with incorrect powerOutletId (must begin with E)" in {

--- a/src/test/scala/com/thenewmotion/mobilityid/EvseIdSpec.scala
+++ b/src/test/scala/com/thenewmotion/mobilityid/EvseIdSpec.scala
@@ -8,33 +8,11 @@ class EvseIdSpec extends Specification {
 
     "Parse ISO string format" should {
       "Accept an ISO EvseId String with separators" in {
-        EvseId("DE*AB7*E840*6487") match {
-          case Some(e: EvseIdIso) =>
-            e.countryCode mustEqual CountryCode("DE")
-            e.operatorId mustEqual OperatorId("AB7")
-            e.powerOutletId mustEqual "E840*6487"
-          case _ => ko
-        }
+        EvseId("DE*AB7*E840*6487") must beSome(EvseId("DE", "AB7", "840*6487"))
       }
 
       "Accept an ISO EvseId String without separators" in {
-        EvseId("DEAB7E8406487") match {
-          case Some(e: EvseIdIso) =>
-            e.countryCode mustEqual CountryCode("DE")
-            e.operatorId mustEqual OperatorId("AB7")
-            e.powerOutletId mustEqual "E8406487"
-          case _ => ko
-        }
-      }
-
-      "Allow to construct an EvseIdIso directly" in {
-        EvseIdIso("DE*AB7*E840*6487") match {
-          case Some(e: EvseId) =>
-            e.countryCode mustEqual CountryCode("DE")
-            e.operatorId mustEqual OperatorId("AB7")
-            e.powerOutletId mustEqual "E840*6487"
-          case _ => ko
-        }
+        EvseId("DEAB7E8406487") must beSome(EvseId("DE", "AB7", "8406487"))
       }
 
       "Accept a minimum length ISO EvseId String" in {
@@ -140,17 +118,18 @@ class EvseIdSpec extends Specification {
         evseId.powerOutletId mustEqual "840*6487"
       }
 
-      "Reject wrong formats when creating EvseIdDin or EvseIdIso" in {
+      "Reject EvseIdIso's country/operator codes when creating EvseIdDin" in {
+        EvseIdDin("NL", "TNM", "840*6487") must throwA[IllegalArgumentException]
+      }
+
+      "Reject EvseIdDin's country/operator codes when creating EvseIdIso" in {
         EvseIdIso("+31", "745", "840*6487") must throwA[IllegalArgumentException]
-        EvseIdDin("NL", "TNM", "E840*6487") must throwA[IllegalArgumentException]
-        EvseIdIso("NL", "TNM", "840*6487") must throwA[IllegalArgumentException]
       }
 
       "Reject mixed ISO/DIN formats" in {
         EvseId("+31", "ABC", "840*6487") must throwA[IllegalArgumentException]
         EvseId("+31", "745", "E840*6487") must throwA[IllegalArgumentException]
         EvseId("+31", "745", "840*6487E") must throwA[IllegalArgumentException]
-        EvseId("NL", "745", "840*6487") must throwA[IllegalArgumentException]
       }
 
       "Reject input fields with wrong lengths" in {
@@ -166,11 +145,11 @@ class EvseIdSpec extends Specification {
 
     "Render" should {
       "Render an EvseId in the ISO form with asterisks" in {
-        EvseId("NL", "TNM", "E840*6487").toString mustEqual "NL*TNM*E840*6487"
+        EvseId("NL", "TNM", "840*6487").toString mustEqual "NL*TNM*E840*6487"
       }
 
       "Render an EvseId in the Compact ISO form without asterisks" in {
-        EvseId("NL", "TNM", "E840*6487") match {
+        EvseId("NL", "TNM", "840*6487") match {
           case evseId: EvseIdIso => evseId.toCompactString mustEqual "NLTNME8406487"
           case _ => ko
         }


### PR DESCRIPTION
This bugfix commit breaks backward compatibility!!!

By mistake ID Type character was added to Power Outlet ID part.
But it does not belong to this part. For details see
 https://github.com/e-clearing-net/OCHP/blob/master/OCHP.md#evseid