### PR TITLE
Put countries in set to improve validity check performance

### DIFF
--- a/core/src/main/scala/com/thenewmotion/mobilityid/basicIdentifiers.scala
+++ b/core/src/main/scala/com/thenewmotion/mobilityid/basicIdentifiers.scala
@@ -30,10 +30,11 @@ private case class CountryCodeImpl(cc: String) extends CountryCode {
 object CountryCode {
   val Regex = """([A-Za-z]{2})""".r
 
-  lazy val isoCountries = Locale.getISOCountries
+  lazy val isoCountries: Array[String] = Locale.getISOCountries
+  private val isoCountriesSet = isoCountries.toSet
 
   def isValid(countryCode: String): Boolean = countryCode match {
-    case Regex(_) if isoCountries.contains(countryCode.toUpperCase) => true
+    case Regex(_) if isoCountriesSet.contains(countryCode.toUpperCase) => true
     case _ => false
   }
 

--- a/core/src/main/scala/com/thenewmotion/mobilityid/basicIdentifiers.scala
+++ b/core/src/main/scala/com/thenewmotion/mobilityid/basicIdentifiers.scala
@@ -30,11 +30,10 @@ private case class CountryCodeImpl(cc: String) extends CountryCode {
 object CountryCode {
   val Regex = """([A-Za-z]{2})""".r
 
-  lazy val isoCountries: Array[String] = Locale.getISOCountries
-  private val isoCountriesSet = isoCountries.toSet
+  lazy val isoCountries: Set[String] = Locale.getISOCountries.toSet
 
   def isValid(countryCode: String): Boolean = countryCode match {
-    case Regex(_) if isoCountriesSet.contains(countryCode.toUpperCase) => true
+    case Regex(_) if isoCountries.contains(countryCode.toUpperCase) => true
     case _ => false
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.1-SNAPSHOT"
+version in ThisBuild := "1.1.0-SNAPSHOT"


### PR DESCRIPTION
I didn't change the type of `isoCountries` to set to make this a non-backwards compatible change. Instead, I created an extra private field.